### PR TITLE
Update README.md for people new to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 Each component directory contains a respective `story.js` file.
 
 ### Usage
+* `npm install` or for faster, deterministic, dependency management, install [yarn](https://yarnpkg.com/en/docs/install) and run `yarn` to install dependencies. For more information on how to use yarn see the [docs](https://yarnpkg.com/en/docs/cli/).
 * `npm run storybook`
 * Visit http://localhost:6006
 * Develop/Style components as normal. Changes will be hot reloaded.
@@ -27,9 +28,6 @@ Each component directory contains a respective `story.js` file.
 Each component directory contains a respective `<Component>.scss` file. `src/scss/main.scss` contains all component imports along with other global imports.
 
 ## Scripts
-
-### Note
-For faster, deterministic, dependency management, install [yarn](https://yarnpkg.com/en/docs/install) and run `yarn` to install dependencies. For more information on how to use yarn see the [docs](https://yarnpkg.com/en/docs/cli/).
 
 ### `build` – build the app
 


### PR DESCRIPTION
## Purpose:
- Update README.md for people new to node

## Description:
- Some people just getting started with node might not know to do this step

## Notes:
- When I followed the readme line by line I got this error:

```
$ npm run storybook

> scrummy-react-dom@2.0.8 storybook /Users/developer/repos/contrib/scrummy-react-dom
> start-storybook -p 6006

sh: start-storybook: command not found

npm ERR! Darwin 15.6.0
npm ERR! argv "/Users/developer/.nvm/versions/node/v6.8.1/bin/node" "/Users/developer/.nvm/versions/node/v6.8.1/bin/npm" "run" "storybook"
npm ERR! node v6.8.1
npm ERR! npm  v3.10.8
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! scrummy-react-dom@2.0.8 storybook: `start-storybook -p 6006`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the scrummy-react-dom@2.0.8 storybook script 'start-storybook -p 6006'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the scrummy-react-dom package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     start-storybook -p 6006
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs scrummy-react-dom
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls scrummy-react-dom
npm ERR! There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/developer/repos/contrib/scrummy-react-dom/npm-debug.log
```

Updating the readme should fix people encountering this error.

Something else we might want to add to the readme is what version of node the project is built to work with.  I am not seeing that documented right now.