### PR TITLE
Warning on build if local.yaml doesn't exist

### DIFF
--- a/.emdaer.yml
+++ b/.emdaer.yml
@@ -21,7 +21,9 @@
         image: 'david/dev/fourkitchens/scrummy-react-dom.svg'
         link: 'https://david-dm.org/dev/fourkitchens/scrummy-react-dom#info=devDependencies&view=table'
 - contributors: true
+- include: './docs/setup.md'
 - include: './docs/storybook.md'
 - include: './docs/styles.md'
 - include: './docs/scripts.md'
+- include: './docs/backend.md'
 - license: true

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ npm run storybook-build
 ### Scrummy Server:
 * Copy `config/example.local.yaml` to `config/local.yaml` to connect to the [Scrummy Server](https://github.com/fourkitchens/scrummy-server).
 * In the Scrummy Server repo change `config/default.yml` to have a port line that reads `port: 8081`.
-* Open two terminal windows and start up both apps with `npm run start` in the projects root directories.
+* Open two terminal windows and start up both apps with `npm run start` in the projects' root directories.
 * Go to: http://localhost:8080/webpack-dev-server/
 * Play Scrummy.
 

--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ npm run storybook-build
 ## Local Backend Server Setup:
 
 ### Note:
-* The default is to connect to the Herokuapp at ws://scrummy-server.herokuapp.com.
+* The deployed application connects to ws://scrummy-server.herokuapp.com.
 
 ### Scrummy Server:
 * Copy `config/example.local.yaml` to `config/local.yaml` to connect to the [Scrummy Server](https://github.com/fourkitchens/scrummy-server).
 * In the Scrummy Server repo change `config/default.yml` to have a port line that reads `port: 8081`.
-* Open two terminal windows and start up both dev servers with `npm run start` in the projects root directories.
+* Open two terminal windows and start up both apps with `npm run start` in the projects root directories.
 * Go to: http://localhost:8080/webpack-dev-server/
 * Play Scrummy.
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@
 [![Four Kitchens](https://avatars.githubusercontent.com/u/348885?s=130)](https://github.com/fourkitchens) | [![Taylor](https://avatars.githubusercontent.com/u/1486573?s=130)](https://github.com/tsmith512) | [![Flip](https://avatars.githubusercontent.com/u/1306968?s=130)](https://github.com/flipactual) | [![Luke](https://avatars.githubusercontent.com/u/1127238?s=130)](https://github.com/infiniteluke)
 --- | --- | --- | ---
 [Four Kitchens](https://github.com/fourkitchens) | [Taylor](https://github.com/tsmith512) | [Flip](https://github.com/flipactual) | [Luke](https://github.com/infiniteluke)
+## Setup
+
+* `yarn` For faster, deterministic, dependency management, install [yarn](https://yarnpkg.com/en/docs/install). For more information on how to use yarn see the [docs](https://yarnpkg.com/en/docs/cli/).
+* `npm install` is not necessary if you use `yarn` but it also works.
+
 ## Storybook
 
 [Storybook](https://github.com/kadirahq/react-storybook) allows one to develop/style components in isolation.
 Each component directory contains a respective `story.js` file.
 
 ### Usage
-* `npm install` or for faster, deterministic, dependency management, install [yarn](https://yarnpkg.com/en/docs/install) and run `yarn` to install dependencies. For more information on how to use yarn see the [docs](https://yarnpkg.com/en/docs/cli/).
 * `npm run storybook`
 * Visit http://localhost:6006
 * Develop/Style components as normal. Changes will be hot reloaded.
@@ -113,6 +117,18 @@ npm run storybook
 ```sh
 npm run storybook-build
 ```
+
+## Local Backend Server Setup:
+
+### Note:
+* The default is to connect to the Herokuapp at ws://scrummy-server.herokuapp.com.
+
+### Scrummy Server:
+* Copy `config/example.local.yaml` to `config/local.yaml` to connect to the [Scrummy Server](https://github.com/fourkitchens/scrummy-server).
+* In the Scrummy Server repo change `config/default.yml` to have a port line that reads `port: 8081`.
+* Open two terminal windows and start up both dev servers with `npm run start` in the projects root directories.
+* Go to: http://localhost:8080/webpack-dev-server/
+* Play Scrummy.
 
 ## License
 

--- a/config/example.local.yaml
+++ b/config/example.local.yaml
@@ -1,0 +1,1 @@
+apiUrl: ws://localhost:8081

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,0 +1,11 @@
+## Local Backend Server Setup:
+
+### Note:
+* The default is to connect to the Herokuapp at ws://scrummy-server.herokuapp.com.
+
+### Scrummy Server:
+* Copy `config/example.local.yaml` to `config/local.yaml` to connect to the [Scrummy Server](https://github.com/fourkitchens/scrummy-server).
+* In the Scrummy Server repo change `config/default.yml` to have a port line that reads `port: 8081`.
+* Open two terminal windows and start up both dev servers with `npm run start` in the projects root directories.
+* Go to: http://localhost:8080/webpack-dev-server/
+* Play Scrummy.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,11 +1,11 @@
 ## Local Backend Server Setup:
 
 ### Note:
-* The default is to connect to the Herokuapp at ws://scrummy-server.herokuapp.com.
+* The deployed application connects to ws://scrummy-server.herokuapp.com.
 
 ### Scrummy Server:
 * Copy `config/example.local.yaml` to `config/local.yaml` to connect to the [Scrummy Server](https://github.com/fourkitchens/scrummy-server).
 * In the Scrummy Server repo change `config/default.yml` to have a port line that reads `port: 8081`.
-* Open two terminal windows and start up both dev servers with `npm run start` in the projects root directories.
+* Open two terminal windows and start up both apps with `npm run start` in the projects root directories.
 * Go to: http://localhost:8080/webpack-dev-server/
 * Play Scrummy.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -6,6 +6,6 @@
 ### Scrummy Server:
 * Copy `config/example.local.yaml` to `config/local.yaml` to connect to the [Scrummy Server](https://github.com/fourkitchens/scrummy-server).
 * In the Scrummy Server repo change `config/default.yml` to have a port line that reads `port: 8081`.
-* Open two terminal windows and start up both apps with `npm run start` in the projects root directories.
+* Open two terminal windows and start up both apps with `npm run start` in the projects' root directories.
 * Go to: http://localhost:8080/webpack-dev-server/
 * Play Scrummy.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,8 +1,5 @@
 ## Scripts
 
-### Note
-For faster, deterministic, dependency management, install [yarn](https://yarnpkg.com/en/docs/install) and run `yarn` to install dependencies. For more information on how to use yarn see the [docs](https://yarnpkg.com/en/docs/cli/).
-
 ### `build` – build the app
 
 ```sh

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,4 @@
+## Setup
+
+* `yarn` For faster, deterministic, dependency management, install [yarn](https://yarnpkg.com/en/docs/install). For more information on how to use yarn see the [docs](https://yarnpkg.com/en/docs/cli/).
+* `npm install` is not necessary if you use `yarn` but it also works.


### PR DESCRIPTION
## Purpose:
- Warning on build if local.yaml doesn't exist

## Note to reviewer:
- I would love to see any other uses for the local.yml file added to this PR.  I am curious how other developers are using it.  Attaching to a local backend was the only use case I could see right now.

## Reproduce warning:
- Get a fresh copy of scrummy
- Run `yarn`
- Run `npm run build`
- Notice this warning:
```
WARNING in ./config/index.js
Module not found: Error: Cannot resolve 'file' or 'directory' ./local.yaml in /Users/developer/repos/contrib/scrummy-react-dom/config
 @ ./config/index.js 9:16-39
```

## Notes:
- It appears that someone has looked into this before because it is enclosed in a try catch
- I looked into using the fs module to check if the file exists with no luck.  Apparently webkit doesn't like the fs module and this might be because this is eventually sent into someone's browser.
- After much trial and error with the fs module I decided it was easier to just commit a blank local.yaml file.  Found out that changes will attempt to be committed if anyone makes any so I removed the file.
- Decided updating the docs was a better approach here.
- Didn't realize that the README.md was auto generated in my last PR so I fixed my mistake of directly editing the README.md and used emdaer this time around.

## Testing:
- Follow the reproduce bug steps but notice the error is gone.